### PR TITLE
Add share project to the config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,6 @@ typings/
 .next
 
 config/secrets.json
-config/config.js
+# config/config.js
 secret.tar
+yarn.lock

--- a/config/config.js
+++ b/config/config.js
@@ -48,6 +48,7 @@ exports.activity = {
       "opendatakit/governance",
       "opendatakit/javarosa",
       "opendatakit/roadmap",
+      "opendatakit/share",
       "opendatakit/slack-server",
       "opendatakit/validate",
       "opendatakit/website",

--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,76 @@
+/**
+  * OPEN DATA KIT ZULIPBOT CONFIGURATION
+  *
+  * See https://github.com/zulip/zulipbot/wiki/configuration for detailed
+  * explanations on each option.
+  */
+
+exports.issues = {
+  commands: {
+    assign: {
+      claim: ["claim"],
+      abandon: ["abandon", "unclaim", "abort"],
+      limit: 1,
+      newContributors: {
+        permission: "pull",
+        restricted: 2,
+        warn: {
+          labels: ["help wanted", "good first issue"],
+        }
+      }
+    },
+    label: {
+      add: ["label", "add"],
+      remove: ["unlabel", "remove"]
+    }
+  }
+};
+
+exports.pulls = {
+  status: {
+    mergeConflicts: true,
+    wip: "WIP"
+  }
+};
+
+exports.activity = {
+  inactive: "inactive",
+  check: {
+    repositories: [
+      "opendatakit/aggregate",
+      "opendatakit/briefcase",
+      "opendatakit/build",
+      "opendatakit/central",
+      "opendatakit/central-backend",
+      "opendatakit/central-frontend",
+      "opendatakit/collect",
+      "opendatakit/docs",
+      "opendatakit/governance",
+      "opendatakit/javarosa",
+      "opendatakit/roadmap",
+      "opendatakit/slack-server",
+      "opendatakit/validate",
+      "opendatakit/website",
+      "opendatakit/xforms-spec"
+      "opendatakit/xlsform-offline",
+      "opendatakit/xlsform-online",
+      "opendatakit/xlsform-server"
+    ],
+    interval: 1, // heroku restarts every 2 hrs and resets counter, so check hourly.
+    reminder: 10,
+    limit: 5
+  },
+  issues: {
+    inProgress: "in progress",
+    clearClosed: true
+  },
+  pullRequests: {
+    reviewed: {
+      label: "reviewed"
+    },
+    needsReview: {
+      label: "needs review",
+      ignore: true
+    }
+  }
+};

--- a/config/templates/claimWarning.md
+++ b/config/templates/claimWarning.md
@@ -1,5 +1,5 @@
 Hello @{commenter}!
 
-You have attempted to claim an issue {state} the {labelGrammar} {list}. It seems like you are new to Zulip, so we suggest working on an issue with the [help wanted](https://github.com/{repoOwner}/{repoName}/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22help+wanted%22) or [good first issue](https://github.com/{repoOwner}/{repoName}/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22good+first+issue%22) label first. We also recommend reading our [guide for new contributors](https://zulip.readthedocs.io/en/latest/overview/contributing.html) before getting started.
+You have attempted to claim an issue {state} the {labelGrammar} {list}. It seems like you are new to Open Data Kit, so we suggest working on a [good first issue](https://github.com/{repoOwner}/{repoName}/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22good+first+issue%22) issue first. After doing one quick win, then try a [help wanted](https://github.com/{repoOwner}/{repoName}/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22help+wanted%22) issue. We also recommend reading [README.md](https://github.com/{repoOwner}/{repoName}/README.md) and [CONTRIBUTING.md](https://github.com/{repoOwner}/{repoName}/CONTRIBUTING.md) before getting started.
 
 To claim this issue anyway, comment on this issue again with the command `@{username} claim --force`.

--- a/config/templates/contributorAddition.md
+++ b/config/templates/contributorAddition.md
@@ -1,10 +1,8 @@
-Welcome to Zulip, @{commenter}! We just sent you an invite to collaborate on this repository at https://github.com/{repoOwner}/{repoName}/invitations. Please accept this invite in order to claim this issue and begin a fun, rewarding experience contributing to Zulip!
+Welcome to Open Data Kit, @{commenter}! We just sent you an invite to collaborate on this repository at https://github.com/{repoOwner}/{repoName}/invitations. Please accept this invite in order to claim this issue and begin a fun and rewarding experience contributing to Open Data Kit!
 
-Here's some tips to get you off to a good start:
-* Join me on the [Zulip developers' server](https://chat.zulip.org), to get help, chat about this issue, and meet the other developers.
-* Sign the [Dropbox Contributor License Agreement](https://opensource.dropbox.com/cla/), so that Zulip can use your code.
-* [Unwatch this repository](https://help.github.com/articles/unwatching-repositories/), so that you don't get 100 emails a day.
-
-As you work on this issue, you'll also want to refer to the [Zulip code contribution guide](https://zulip.readthedocs.io/en/latest/contributing/index.html), as well as the rest of the developer documentation on that site.
+Here are some tips to get you off to a good start:
+* Please read the README.md and CONTRIBUTING.md in this repo. Those two documents have much of what you need to get started. 
+* Join the [ODK developer Slack](http://slack.opendatakit.org/) to get help, chat about this issue, and meet the other developers.
+* Sign up and introduce yourself on the [ODK community forum](https://forum.opendatakit.org/) to meet the broader ODK community.
 
 See you on the other side (that is, the pull request side)!

--- a/config/templates/fixCommitWarning.md
+++ b/config/templates/fixCommitWarning.md
@@ -5,7 +5,7 @@ Please run `git commit --amend` in your command line client to amend your commit
 An example of a correctly-formatted commit:
 ```
 commit fabd5e450374c8dde65ec35f02140383940fe146
-Author: zulipbot
+Author: opendatakit-bot
 Date:   Sat Mar 18 13:42:40 2017 -0700
 
     pull requests: Check PR commits reference when issue is referenced.
@@ -13,6 +13,6 @@ Date:   Sat Mar 18 13:42:40 2017 -0700
     Fixes #51.
 ```
 
-Thank you for your contributions to Zulip!
+Thank you for your contributions to Open Data Kit!
 
 <!-- fixCommitWarning -->

--- a/config/templates/inactiveWarning.md
+++ b/config/templates/inactiveWarning.md
@@ -2,8 +2,8 @@ Hello @{assignee}, you claimed this issue to work on it, but this issue and any 
 
 If so, please update this issue by leaving a comment on this issue to let me know that you're still working on it. Otherwise, I'll automatically remove you from this issue in {abandon} days.
 
-If you've decided to work on something else, simply comment `@{username} abandon` so that someone else can claim it and continue from where you left off.
+If you've decided to work on something else, simply comment `@{username} unclaim` so that someone else can claim it and continue from where you left off.
 
-Thank you for your valuable contributions to Zulip!
+Thank you for your valuable contributions to Open Data Kit!
 
 <!-- inactiveWarning -->

--- a/config/templates/updateWarning.md
+++ b/config/templates/updateWarning.md
@@ -1,5 +1,5 @@
-Hello @{author}, a Zulip maintainer reviewed this pull request over {days} days ago, but you haven't updated your pull request since. Please take a look at the requested changes and update your pull request accordingly.
+Hello @{author}, an Open Data Kit maintainer reviewed this pull request over {days} days ago, but you haven't updated your pull request since. Please take a look at the requested changes and update your pull request accordingly.
 
-Thank you for your valuable contributions to Zulip!
+Thank you for your valuable contributions to Open Data Kit!
 
 <!-- updateWarning -->


### PR DESCRIPTION
As requested by one of the contributors, it'd be nice to have the :robot:  supervise @opendatakit/share repo as well
https://github.com/opendatakit/share/issues/117#issuecomment-466737815